### PR TITLE
Add How to Use Xdebug for Advanced PHP Debugging

### DIFF
--- a/resources/views/welcome.blade.php
+++ b/resources/views/welcome.blade.php
@@ -128,6 +128,7 @@
                     <li class="mb-2"><a href="https://tighten.co/blog/debugging-configure-xdebug-and-laravel-homestead-and-vs-code-and-phpunit/">Debugging: Configure Xdebug + Laravel Homestead + VS Code + PHPUnit</a></li>
                     <li class="mb-2"><a href="https://jump24.co.uk/journal/turbocharged-php-development-with-xdebug-docker-and-phpstorm/">Turbocharged PHP Development with Xdebug, Docker & PHPStorm</a></li>
                     <li class="mb-2"><a href="http://blog.chorip.am/articles/faster-environment-with-xDebug-and-Docker">Faster environment with xDebug and Docker</a></li>
+                    <li class="mb-2"><a href="https://deliciousbrains.com/xdebug-advanced-php-debugging/">How to Use Xdebug for Advanced PHP Debugging</a></li>
                     <li class="mb-2"><a href="https://jonathanbossenger.com/zero-configuration-debugging-php-with-xdebug-in-phpstorm-on-ubuntu/">Zero-configuration debugging PHP with Xdebug in PHPStorm on Ubuntu</a></li>
                 </ul>
             </div>


### PR DESCRIPTION
In my new role as Developer Educator at Delicious Brains, we recently updated our Xdebug article. It includes quite a big list of popular WordPress development environments, and how to set up Xdebug in each, as well as details on using version 2 vs version 3, and some more advanced applications like profiling. So I thought it would be useful to add to the list.